### PR TITLE
Use parameter defined by Alt-Svc spec

### DIFF
--- a/draft-duke-httpbis-quic-version-alt-svc.md
+++ b/draft-duke-httpbis-quic-version-alt-svc.md
@@ -97,23 +97,22 @@ This document specifies the "quicv" Alt-Svc parameter, which lists the QUIC
 versions supported by an endpoint, using the hexadecimal representation of the
 version field in a QUIC long header, as indicated in {{RFC8999}}.
 
-``` abnf
+~~~ abnf
 quicv         = version-list
-version-list  = DQUOTE version-number 1*( OWS, "," OWS version-number) DQUOTE
-version-number = 1*8 HEXDIG; hex-encoded QUIC version
-```
+version-list  = DQUOTE version 1*( OWS, "," OWS version-number) DQUOTE
+version = 1*8 HEXDIG; hex-encoded QUIC version
+~~~
 
 For example:
 
-```
+~~~
 Alt-Svc: h3=":443"; quicv="1"
 Alt-Svc: h3=":443"; quicv="2,1"
 Alt-Svc: h3=":443"; quicv="2,1", h3=":1001"; quicv="2"
-```
+~~~
 
-When multiple version-number are present in the quicv parameter, the order of
-the values reflects the server's preference (with the first value being the most
-preferred alternative).
+The order of entries in version-list reflects the server's preference (with the
+first value being the most preferred alternative).
 
 Note that the quicv parameter applies to a single associated entry in the
 Alt-Svc list. Servers MUST NOT provide a quicv parameter to an entry containing

--- a/draft-duke-httpbis-quic-version-alt-svc.md
+++ b/draft-duke-httpbis-quic-version-alt-svc.md
@@ -103,12 +103,12 @@ version-list  = DQUOTE version 1*( OWS, "," OWS version-number) DQUOTE
 version = 1*8 HEXDIG; hex-encoded QUIC version
 ~~~
 
-For example:
+Examples:
 
 ~~~
 Alt-Svc: h3=":443"; quicv="1"
-Alt-Svc: h3=":443"; quicv="2,1"
-Alt-Svc: h3=":443"; quicv="2,1", h3=":1001"; quicv="2"
+Alt-Svc: h3=":443"; quicv="709a50c4,1"
+Alt-Svc: h3=":443"; quicv="709a50c4,1", h3=":1001"; quicv="709a50c4"
 ~~~
 
 The order of entries in version-list reflects the server's preference (with the

--- a/draft-duke-httpbis-quic-version-alt-svc.md
+++ b/draft-duke-httpbis-quic-version-alt-svc.md
@@ -28,7 +28,7 @@ author:
     email: lucaspardue.24.7@gmail.com
 
 normative:
-    
+
 
 informative:
 
@@ -88,31 +88,40 @@ connect successfully using the most desirable version with high probability.
 
 {::boilerplate bcp14-tagged}
 
-This document uses the Augmented BNF defined in {{!RFC5234}} and structured
-fields defined in {{!RFC8941}}.
+This document uses the Augmented BNF defined in {{!RFC5234}} and imports
+`parameter` from {{Section 3 of ALTSVC}}.
 
 # The quicv Parameter
 
-This document specifies the "quicv" parameter, which lists the QUIC versions
-supported by an endpoint.
+This document specifies the "quicv" Alt-Svc parameter, which lists the QUIC
+versions supported by an endpoint, using the hexadecimal representation of the
+version field in a QUIC long header, as indicated in {{RFC8999}}.
+
+``` abnf
+quicv         = version-list
+version-list  = DQUOTE version-number 1*( OWS, "," OWS version-number) DQUOTE
+version-number = 1*8 HEXDIG; hex-encoded QUIC version
+```
+
+For example:
 
 ```
-parameter       = param-key "=" param-value
-param-key       = "quicv"
-param-value     = version 1*( OWS, "," OWS version) 
-version         = 8(HEXDIG)
+Alt-Svc: h3=":443"; quicv="1"
+Alt-Svc: h3=":443"; quicv="2,1"
+Alt-Svc: h3=":443"; quicv="2,1", h3=":1001"; quicv="2"
 ```
 
-The "version" field is the hexadecimal representation of the version field in a
-QUIC long header, as indicated in {{RFC8999}}.
+When multiple version-number are present in the quicv parameter, the order of
+the values reflects the server's preference (with the first value being the most
+preferred alternative).
 
-Note that each parameter applies to a single entry in the Alt-Svc list. Servers
-MUST NOT append a quicv parameter to an ALPN that does not potentially utilize
-QUIC.
+Note that the quicv parameter applies to a single associated entry in the
+Alt-Svc list. Servers MUST NOT provide a quicv parameter to an entry containing
+ALPN codepoint that does not potentially utilize QUIC.
 
-If the Alt-Svc information resolves to a server pool that inconsistenly supports
-different QUIC versions, the parameter SHOULD only advertise versions that are
-supported throughout the pool.
+If the Alt-Svc information resolves to a server pool that inconsistently
+supports different QUIC versions, the parameter SHOULD only advertise versions
+that are supported throughout the pool.
 
 # Security Considerations
 


### PR DESCRIPTION
Few points here, I might have misinterpreted things though so open to debate.

I have an alternative design in mind, but it seemed important to agree on what your initial design and fixing that up before debating alternatives

0. There's some prior art in this area from gQUIC adoption and Mikes work to corale that, see https://datatracker.ietf.org/doc/html/draft-ietf-quic-http-01#section-2.1 from which I stole some ABNF
1. You didn't provide an example, which makes it tougher to know what you expected this to look like if we put aside ABNF arguments. That said...
1. Alt-Svc isn't a structured field. It already defines it's own parameter ABNF, so lets just use that, which means we have to provide a token or quoted string. If you had "bare" commas in the parameter, a HTTP parser would have detected that as a new entry
2. So I plumped for a quoted string of comma-separated hex encoded vales.
3. But I took off the restriction to maximally encode them (i.e use `1` not `00000001`)
4. Any time there is a list of things, we should state if the list order matters. I picked first == most preferred, as that mirrors Alt-Svc entry order.